### PR TITLE
Update the build SDK to version 3.1.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,13 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "dependencies"
+      - "nuget"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+      - "gh-actions"

--- a/.github/github-labels.yml
+++ b/.github/github-labels.yml
@@ -36,6 +36,14 @@
   color: '008672'
   description: "Changes related to unit tests"
 
+# Additional Labels Used by Dependabot
+- name: gh-actions
+  color: '1d0128'
+  description: "Version updates for GitHub actions"
+- name: nuget
+  color: '1d0128'
+  description: "Version updates for NuGet packages"
+
 # Additional Labels for Release Drafter Version Resolution
 - name: bump-major-version
   color: 'cf996b'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,52 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+  pull_request:
+    branches:
+      - 'main'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      dotnet-version: 8.0.x
+    strategy:
+      matrix:
+        configuration: ['Debug', 'Release']
+
+    steps:
+    - name: Check out the project
+      uses: actions/checkout@v4
+    - name: Set up .NET ${{env.dotnet-version}}
+      uses: actions/setup-dotnet@v4
+      id: setup
+      with:
+        dotnet-version: ${{env.dotnet-version}}
+      env:
+        NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+    - name: Create global.json to force use of .NET SDK ${{steps.setup.outputs.dotnet-version}}
+      run: echo '{"sdk":{"version":"${{steps.setup.outputs.dotnet-version}}"}}' > ./global.json
+    - name: Run build script (${{matrix.configuration}})
+      run: pwsh ./build-package.ps1 -ContinuousIntegration -WithBinLog -Configuration ${{matrix.configuration}}
+    - name: "Artifact: MSBuild Logs"
+      uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        name: MSBuild Logs (${{matrix.configuration}})
+        path: msbuild.*.binlog
+    - name: "Artifact: NuGet Packages"
+      uses: actions/upload-artifact@v3
+      with:
+        name: NuGet Packages (${{matrix.configuration}})
+        path: "output/package/${{matrix.configuration}}/*.*nupkg"
+    - name: Publish (NuGet - GitHub Packages)
+      if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
+      run: "dotnet nuget push output/package/${{matrix.configuration}}/*.nupkg -s https://nuget.pkg.github.com/zastai/index.json -k ${{secrets.GITHUB_TOKEN}}"
+    - name: Publish (NuGet - nuget.org)
+      if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
+      run: "dotnet nuget push output/package/${{matrix.configuration}}/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}}"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,6 +10,6 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v5.15.0
+      - uses: release-drafter/release-drafter@v5.25.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-labels.yml
+++ b/.github/workflows/update-labels.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Labeler
         if: success()
-        uses: crazy-max/ghaction-github-labeler@v3
+        uses: crazy-max/ghaction-github-labeler@v5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           yaml-file: .github/github-labels.yml

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2021 Tim Van Holder
+Copyright (c) 2016-2023 Tim Van Holder
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/MetaBrainz.MusicBrainz.DiscId.sln
+++ b/MetaBrainz.MusicBrainz.DiscId.sln
@@ -1,17 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.0.31912.275
+VisualStudioVersion = 17.8.34330.188
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Support Files", "Support Files", "{F997B31A-CF25-4C63-BEB5-172F7E13D9B3}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
-		appveyor.yml = appveyor.yml
 		build-package.ps1 = build-package.ps1
 		Directory.Packages.props = Directory.Packages.props
-		global.json = global.json
 		LICENSE.md = LICENSE.md
 		package-icon.png = package-icon.png
 		README.md = README.md
@@ -26,6 +24,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GitHub", "GitHub", "{935533
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Actions", "Actions", "{9FD24444-85F6-4C28-AFA0-3F00E9F307F0}"
 	ProjectSection(SolutionItems) = preProject
+		.github\workflows\build.yml = .github\workflows\build.yml
 		.github\workflows\release-drafter.yml = .github\workflows\release-drafter.yml
 		.github\workflows\update-labels.yml = .github\workflows\update-labels.yml
 	EndProjectSection

--- a/MetaBrainz.MusicBrainz.DiscId/MetaBrainz.MusicBrainz.DiscId.csproj
+++ b/MetaBrainz.MusicBrainz.DiscId/MetaBrainz.MusicBrainz.DiscId.csproj
@@ -1,13 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MetaBrainz.Build.Sdk">
+<Project>
+
+  <Sdk Name="MetaBrainz.Build.Sdk" Version="3.1.0" />
 
   <PropertyGroup>
+    <Authors>Zastai</Authors>
     <Title>MusicBrainz DiscID Library</Title>
     <Description>This package provides classes for accessing information about a CD (its MusicBrainz Disc ID, EAN/ISRC values, CD-TEXT info, ...).</Description>
-    <PackageCopyrightYears>2016-2021</PackageCopyrightYears>
+    <PackageCopyrightOwners>Tim Van Holder</PackageCopyrightOwners>
+    <PackageCopyrightYears>2016-2023</PackageCopyrightYears>
     <PackageRepositoryName>MetaBrainz.MusicBrainz.DiscId</PackageRepositoryName>
     <PackageTags>MusicBrainz discid audio cd cd-text isrc upc ean libdiscid</PackageTags>
-    <Version>3.0.1-pre</Version>
+    <Version>4.0.0-pre</Version>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <AssemblyIsComVisible>false</AssemblyIsComVisible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MetaBrainz.MusicBrainz.DiscId/Properties/AssemblyInfo.cs
+++ b/MetaBrainz.MusicBrainz.DiscId/Properties/AssemblyInfo.cs
@@ -1,3 +1,0 @@
-using System.Runtime.InteropServices;
-
-[assembly: ComVisible(false)]

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ easy way to get Mono to work on it.
 Support for OSX is similarly unlikely, because I have no access to a
 system.
 
-[CI-S]: https://img.shields.io/appveyor/build/zastai/metabrainz-musicbrainz-discid
-[CI-L]: https://ci.appveyor.com/project/Zastai/metabrainz-musicbrainz-discid
+[CI-S]: https://github.com/Zastai/MetaBrainz.MusicBrainz.DiscId/actions/workflows/build.yml/badge.svg
+[CI-L]: https://github.com/Zastai/MetaBrainz.MusicBrainz.DiscId/actions/workflows/build.yml
 
 [NuGet-S]: https://img.shields.io/nuget/v/MetaBrainz.MusicBrainz.DiscId
 [NuGet-L]: https://www.nuget.org/packages/MetaBrainz.MusicBrainz.DiscId

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,0 @@
-version: 'Build #{build}'
-image: Visual Studio 2022
-build_script:
-  - ps: .\build-package.ps1 -Configuration Debug
-after_build:
-  - ps: Get-ChildItem output/package/*/*.nupkg | % { appveyor PushArtifact $_ }

--- a/build-package.ps1
+++ b/build-package.ps1
@@ -3,6 +3,7 @@
 [CmdletBinding()]
 param (
   [string] $Configuration = 'Release',
+  [switch] $ContinuousIntegration = $false,
   [switch] $WithBinLog = $false
 )
 
@@ -41,7 +42,15 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 Write-Host "Building the solution (Configuration: $Configuration)..."
-dotnet build $opts --no-restore "-c:$Configuration" '-p:ContinuousIntegrationBuild=true' '-p:Deterministic=true'
+$props = @()
+if ($ContinuousIntegration) {
+  $props += '-p:ContinuousIntegrationBuild=true'
+  $props += '-p:Deterministic=true'
+}
+if ($Configuration -eq 'Debug') {
+  $props += '-p:DebugMessageImportance=high'
+}
+dotnet build $opts --no-restore "-c:$Configuration" $props
 Complete-BuildStep 'build'
 if ($LASTEXITCODE -ne 0) {
   Write-Error "SOLUTION BUILD FAILED"

--- a/global.json
+++ b/global.json
@@ -1,5 +1,0 @@
-{
-  "msbuild-sdks": {
-    "MetaBrainz.Build.Sdk" : "2.1.2"
-  }
-}

--- a/public-api/MetaBrainz.MusicBrainz.DiscId.net6.0.cs.md
+++ b/public-api/MetaBrainz.MusicBrainz.DiscId.net6.0.cs.md
@@ -1,0 +1,482 @@
+﻿# API Reference: MetaBrainz.MusicBrainz.DiscId
+
+## Assembly Attributes
+
+```cs
+[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
+[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v6.0", FrameworkDisplayName = ".NET 6.0")]
+```
+
+## Namespace: MetaBrainz.MusicBrainz.DiscId
+
+### Type: AlbumText
+
+```cs
+public sealed class AlbumText {
+
+  string? Arranger {
+    public get;
+  }
+
+  string? Composer {
+    public get;
+  }
+
+  MetaBrainz.MusicBrainz.DiscId.Standards.BlueBook.Genre? Genre {
+    public get;
+  }
+
+  string? GenreDescription {
+    public get;
+  }
+
+  string? Identification {
+    public get;
+  }
+
+  string? Lyricist {
+    public get;
+  }
+
+  string? Message {
+    public get;
+  }
+
+  string? Performer {
+    public get;
+  }
+
+  string? ProductCode {
+    public get;
+  }
+
+  string? Title {
+    public get;
+  }
+
+  public AlbumText();
+
+}
+```
+
+### Type: DiscReadFeature
+
+```cs
+[System.FlagsAttribute]
+public enum DiscReadFeature {
+
+  All = -1,
+  CdText = 8,
+  MediaCatalogNumber = 2,
+  None = 0,
+  TableOfContents = 1,
+  TrackIsrc = 4,
+
+}
+```
+
+### Type: ScsiException
+
+```cs
+[System.SerializableAttribute]
+public class ScsiException : System.Runtime.InteropServices.ExternalException {
+
+  byte AdditionalSenseCode {
+    public get;
+  }
+
+  byte AdditionalSenseCodeQualifier {
+    public get;
+  }
+
+  int ErrorCode {
+    public override get;
+  }
+
+  string Message {
+    public override get;
+  }
+
+  byte SenseKey {
+    public get;
+  }
+
+  public ScsiException(byte sk, byte asc, byte ascq);
+
+}
+```
+
+### Type: TableOfContents
+
+```cs
+public sealed class TableOfContents {
+
+  public const int MaxSectors = 449999;
+
+  public const int XAInterval = 11400;
+
+  System.Collections.Generic.IEnumerable<string> AvailableDevices {
+    public static get;
+  }
+
+  DiscReadFeature AvailableFeatures {
+    public static get;
+  }
+
+  string? DefaultDevice {
+    public static get;
+  }
+
+  int DefaultPort {
+    public static get;
+    public static set;
+  }
+
+  string DefaultUrlScheme {
+    public static get;
+    public static set;
+  }
+
+  string DefaultWebSite {
+    public static get;
+    public static set;
+  }
+
+  string? DeviceName {
+    public get;
+  }
+
+  string DiscId {
+    public get;
+  }
+
+  byte FirstTrack {
+    public get;
+  }
+
+  string FreeDbId {
+    public get;
+  }
+
+  byte LastTrack {
+    public get;
+  }
+
+  int Length {
+    public get;
+  }
+
+  string? MediaCatalogNumber {
+    public get;
+  }
+
+  int Port {
+    public get;
+    public set;
+  }
+
+  System.Uri SubmissionUrl {
+    public get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<AlbumText>? TextInfo {
+    public get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<MetaBrainz.MusicBrainz.DiscId.Standards.EBU.LanguageCode>? TextLanguages {
+    public get;
+  }
+
+  AudioTrackCollection Tracks {
+    public get;
+  }
+
+  string UrlScheme {
+    public get;
+    public set;
+  }
+
+  string WebSite {
+    public get;
+    public set;
+  }
+
+  public static bool HasReadFeature(DiscReadFeature feature);
+
+  public static TableOfContents ReadDisc(string? device, DiscReadFeature features = DiscReadFeature.All | DiscReadFeature.CdText | DiscReadFeature.MediaCatalogNumber | DiscReadFeature.None | DiscReadFeature.TableOfContents | DiscReadFeature.TrackIsrc);
+
+  public static TableOfContents SimulateDisc(byte first, byte last, int[] offsets);
+
+  public override string ToString();
+
+  public sealed class AudioTrack {
+
+    System.TimeSpan Duration {
+      public get;
+    }
+
+    string? Isrc {
+      public get;
+    }
+
+    int Length {
+      public get;
+    }
+
+    byte Number {
+      public get;
+    }
+
+    int Offset {
+      public get;
+    }
+
+    System.TimeSpan StartTime {
+      public get;
+    }
+
+    System.Collections.Generic.IReadOnlyList<TrackText>? TextInfo {
+      public get;
+    }
+
+  }
+
+  [System.Reflection.DefaultMemberAttribute("Item")]
+  public sealed class AudioTrackCollection : System.Collections.Generic.IEnumerable<AudioTrack>, System.Collections.Generic.IReadOnlyCollection<AudioTrack>, System.Collections.Generic.IReadOnlyList<AudioTrack>, System.Collections.IEnumerable {
+
+    AudioTrack this[int number] {
+      public sealed override get;
+      public set;
+    }
+
+    int Count {
+      public sealed override get;
+    }
+
+    byte FirstTrack {
+      public get;
+    }
+
+    byte LastTrack {
+      public get;
+    }
+
+    public sealed override System.Collections.Generic.IEnumerator<AudioTrack> GetEnumerator();
+
+  }
+
+}
+```
+
+### Type: TrackText
+
+```cs
+public sealed class TrackText {
+
+  string? Arranger {
+    public get;
+  }
+
+  string? Composer {
+    public get;
+  }
+
+  string? Isrc {
+    public get;
+  }
+
+  string? Lyricist {
+    public get;
+  }
+
+  string? Message {
+    public get;
+  }
+
+  string? Performer {
+    public get;
+  }
+
+  string? Title {
+    public get;
+  }
+
+  public TrackText();
+
+}
+```
+
+## Namespace: MetaBrainz.MusicBrainz.DiscId.Platforms
+
+### Type: UnixException
+
+```cs
+[System.SerializableAttribute]
+public class UnixException : System.Runtime.InteropServices.ExternalException {
+
+  public UnixException();
+
+  public UnixException(int errno);
+
+}
+```
+
+## Namespace: MetaBrainz.MusicBrainz.DiscId.Standards
+
+### Type: BlueBook
+
+```cs
+public static class BlueBook {
+
+  public enum Genre : short {
+
+    AdultContemporary = (short) 2,
+    AlternativeRock = (short) 3,
+    Childrens = (short) 4,
+    Classical = (short) 5,
+    ContemporaryChristian = (short) 6,
+    Country = (short) 7,
+    Dance = (short) 8,
+    EasyListening = (short) 9,
+    Erotic = (short) 10,
+    Folk = (short) 11,
+    Gospel = (short) 12,
+    HipHop = (short) 13,
+    Jazz = (short) 14,
+    Latin = (short) 15,
+    Musical = (short) 16,
+    NewAge = (short) 17,
+    Opera = (short) 18,
+    Operetta = (short) 19,
+    Pop = (short) 20,
+    Rap = (short) 21,
+    Reggae = (short) 22,
+    RhythmAndBlues = (short) 24,
+    Rock = (short) 23,
+    SoundEffects = (short) 25,
+    Soundtrack = (short) 26,
+    SpokenWord = (short) 27,
+    Unknown = (short) 1,
+    Unspecified = (short) 0,
+    WorldMusic = (short) 28,
+
+  }
+
+}
+```
+
+### Type: EBU
+
+```cs
+public static class EBU {
+
+  public enum LanguageCode : byte {
+
+    Albanian = (byte) 1,
+    Amharic = (byte) 127,
+    Arabic = (byte) 126,
+    Armenian = (byte) 125,
+    Assamese = (byte) 124,
+    Azerbaijani = (byte) 123,
+    Bambora = (byte) 122,
+    Basque = (byte) 13,
+    Bengali = (byte) 120,
+    Bielorussian = (byte) 121,
+    Breton = (byte) 2,
+    Bulgarian = (byte) 119,
+    Burmese = (byte) 118,
+    Catalan = (byte) 3,
+    Chinese = (byte) 117,
+    Churash = (byte) 116,
+    Croatian = (byte) 4,
+    Czech = (byte) 6,
+    Danish = (byte) 7,
+    Dari = (byte) 115,
+    Dutch = (byte) 29,
+    English = (byte) 9,
+    Esperanto = (byte) 11,
+    Estonian = (byte) 12,
+    Faroese = (byte) 14,
+    Finnish = (byte) 39,
+    Flemish = (byte) 42,
+    French = (byte) 15,
+    Frisian = (byte) 16,
+    Fulani = (byte) 114,
+    Gaelic = (byte) 18,
+    Galician = (byte) 19,
+    Georgian = (byte) 113,
+    German = (byte) 8,
+    Greek = (byte) 112,
+    Gujurati = (byte) 111,
+    Gurani = (byte) 110,
+    Hausa = (byte) 109,
+    Hebrew = (byte) 108,
+    Hindi = (byte) 107,
+    Hungarian = (byte) 27,
+    Icelandic = (byte) 20,
+    Indonesian = (byte) 106,
+    Irish = (byte) 17,
+    Italian = (byte) 21,
+    Japanese = (byte) 105,
+    Kannada = (byte) 104,
+    Kazakh = (byte) 103,
+    Khmer = (byte) 102,
+    Korean = (byte) 101,
+    Laotian = (byte) 100,
+    Lappish = (byte) 22,
+    Latin = (byte) 23,
+    Latvian = (byte) 24,
+    Lithuanian = (byte) 26,
+    Luxembourgian = (byte) 25,
+    Macedonian = (byte) 99,
+    Malagasay = (byte) 98,
+    Malaysian = (byte) 97,
+    Maltese = (byte) 28,
+    Marathi = (byte) 95,
+    Moldavian = (byte) 96,
+    Ndebele = (byte) 94,
+    Nepali = (byte) 93,
+    Norwegian = (byte) 30,
+    Occitan = (byte) 31,
+    Oriya = (byte) 92,
+    Papamiento = (byte) 91,
+    Persian = (byte) 90,
+    Polish = (byte) 32,
+    Portuguese = (byte) 33,
+    Punjabi = (byte) 89,
+    Pushtu = (byte) 88,
+    Quechua = (byte) 87,
+    Romanian = (byte) 34,
+    Romansh = (byte) 35,
+    Russian = (byte) 86,
+    Ruthenian = (byte) 85,
+    Serbian = (byte) 36,
+    SerboCroat = (byte) 84,
+    Shona = (byte) 83,
+    Sinhalese = (byte) 82,
+    Slovak = (byte) 37,
+    Slovenian = (byte) 38,
+    Somali = (byte) 81,
+    Spanish = (byte) 10,
+    SrananTongo = (byte) 80,
+    Swahili = (byte) 79,
+    Swedish = (byte) 40,
+    Tadzhik = (byte) 78,
+    Tamil = (byte) 77,
+    Tatar = (byte) 76,
+    Telugu = (byte) 75,
+    Thai = (byte) 74,
+    Turkish = (byte) 41,
+    Ukrainian = (byte) 73,
+    Unknown = (byte) 0,
+    Urdu = (byte) 72,
+    Uzbek = (byte) 71,
+    Vietnamese = (byte) 70,
+    Wallon = (byte) 43,
+    Welsh = (byte) 5,
+    Zulu = (byte) 69,
+
+  }
+
+}
+```

--- a/public-api/MetaBrainz.MusicBrainz.DiscId.net8.0.cs.md
+++ b/public-api/MetaBrainz.MusicBrainz.DiscId.net8.0.cs.md
@@ -1,0 +1,482 @@
+﻿# API Reference: MetaBrainz.MusicBrainz.DiscId
+
+## Assembly Attributes
+
+```cs
+[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
+[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v8.0", FrameworkDisplayName = ".NET 8.0")]
+```
+
+## Namespace: MetaBrainz.MusicBrainz.DiscId
+
+### Type: AlbumText
+
+```cs
+public sealed class AlbumText {
+
+  string? Arranger {
+    public get;
+  }
+
+  string? Composer {
+    public get;
+  }
+
+  MetaBrainz.MusicBrainz.DiscId.Standards.BlueBook.Genre? Genre {
+    public get;
+  }
+
+  string? GenreDescription {
+    public get;
+  }
+
+  string? Identification {
+    public get;
+  }
+
+  string? Lyricist {
+    public get;
+  }
+
+  string? Message {
+    public get;
+  }
+
+  string? Performer {
+    public get;
+  }
+
+  string? ProductCode {
+    public get;
+  }
+
+  string? Title {
+    public get;
+  }
+
+  public AlbumText();
+
+}
+```
+
+### Type: DiscReadFeature
+
+```cs
+[System.FlagsAttribute]
+public enum DiscReadFeature {
+
+  All = -1,
+  CdText = 8,
+  MediaCatalogNumber = 2,
+  None = 0,
+  TableOfContents = 1,
+  TrackIsrc = 4,
+
+}
+```
+
+### Type: ScsiException
+
+```cs
+[System.SerializableAttribute]
+public class ScsiException : System.Runtime.InteropServices.ExternalException {
+
+  byte AdditionalSenseCode {
+    public get;
+  }
+
+  byte AdditionalSenseCodeQualifier {
+    public get;
+  }
+
+  int ErrorCode {
+    public override get;
+  }
+
+  string Message {
+    public override get;
+  }
+
+  byte SenseKey {
+    public get;
+  }
+
+  public ScsiException(byte sk, byte asc, byte ascq);
+
+}
+```
+
+### Type: TableOfContents
+
+```cs
+public sealed class TableOfContents {
+
+  public const int MaxSectors = 449999;
+
+  public const int XAInterval = 11400;
+
+  System.Collections.Generic.IEnumerable<string> AvailableDevices {
+    public static get;
+  }
+
+  DiscReadFeature AvailableFeatures {
+    public static get;
+  }
+
+  string? DefaultDevice {
+    public static get;
+  }
+
+  int DefaultPort {
+    public static get;
+    public static set;
+  }
+
+  string DefaultUrlScheme {
+    public static get;
+    public static set;
+  }
+
+  string DefaultWebSite {
+    public static get;
+    public static set;
+  }
+
+  string? DeviceName {
+    public get;
+  }
+
+  string DiscId {
+    public get;
+  }
+
+  byte FirstTrack {
+    public get;
+  }
+
+  string FreeDbId {
+    public get;
+  }
+
+  byte LastTrack {
+    public get;
+  }
+
+  int Length {
+    public get;
+  }
+
+  string? MediaCatalogNumber {
+    public get;
+  }
+
+  int Port {
+    public get;
+    public set;
+  }
+
+  System.Uri SubmissionUrl {
+    public get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<AlbumText>? TextInfo {
+    public get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<MetaBrainz.MusicBrainz.DiscId.Standards.EBU.LanguageCode>? TextLanguages {
+    public get;
+  }
+
+  AudioTrackCollection Tracks {
+    public get;
+  }
+
+  string UrlScheme {
+    public get;
+    public set;
+  }
+
+  string WebSite {
+    public get;
+    public set;
+  }
+
+  public static bool HasReadFeature(DiscReadFeature feature);
+
+  public static TableOfContents ReadDisc(string? device, DiscReadFeature features = DiscReadFeature.All | DiscReadFeature.CdText | DiscReadFeature.MediaCatalogNumber | DiscReadFeature.None | DiscReadFeature.TableOfContents | DiscReadFeature.TrackIsrc);
+
+  public static TableOfContents SimulateDisc(byte first, byte last, int[] offsets);
+
+  public override string ToString();
+
+  public sealed class AudioTrack {
+
+    System.TimeSpan Duration {
+      public get;
+    }
+
+    string? Isrc {
+      public get;
+    }
+
+    int Length {
+      public get;
+    }
+
+    byte Number {
+      public get;
+    }
+
+    int Offset {
+      public get;
+    }
+
+    System.TimeSpan StartTime {
+      public get;
+    }
+
+    System.Collections.Generic.IReadOnlyList<TrackText>? TextInfo {
+      public get;
+    }
+
+  }
+
+  [System.Reflection.DefaultMemberAttribute("Item")]
+  public sealed class AudioTrackCollection : System.Collections.Generic.IEnumerable<AudioTrack>, System.Collections.Generic.IReadOnlyCollection<AudioTrack>, System.Collections.Generic.IReadOnlyList<AudioTrack>, System.Collections.IEnumerable {
+
+    AudioTrack this[int number] {
+      public sealed override get;
+      public set;
+    }
+
+    int Count {
+      public sealed override get;
+    }
+
+    byte FirstTrack {
+      public get;
+    }
+
+    byte LastTrack {
+      public get;
+    }
+
+    public sealed override System.Collections.Generic.IEnumerator<AudioTrack> GetEnumerator();
+
+  }
+
+}
+```
+
+### Type: TrackText
+
+```cs
+public sealed class TrackText {
+
+  string? Arranger {
+    public get;
+  }
+
+  string? Composer {
+    public get;
+  }
+
+  string? Isrc {
+    public get;
+  }
+
+  string? Lyricist {
+    public get;
+  }
+
+  string? Message {
+    public get;
+  }
+
+  string? Performer {
+    public get;
+  }
+
+  string? Title {
+    public get;
+  }
+
+  public TrackText();
+
+}
+```
+
+## Namespace: MetaBrainz.MusicBrainz.DiscId.Platforms
+
+### Type: UnixException
+
+```cs
+[System.SerializableAttribute]
+public class UnixException : System.Runtime.InteropServices.ExternalException {
+
+  public UnixException();
+
+  public UnixException(int errno);
+
+}
+```
+
+## Namespace: MetaBrainz.MusicBrainz.DiscId.Standards
+
+### Type: BlueBook
+
+```cs
+public static class BlueBook {
+
+  public enum Genre : short {
+
+    AdultContemporary = (short) 2,
+    AlternativeRock = (short) 3,
+    Childrens = (short) 4,
+    Classical = (short) 5,
+    ContemporaryChristian = (short) 6,
+    Country = (short) 7,
+    Dance = (short) 8,
+    EasyListening = (short) 9,
+    Erotic = (short) 10,
+    Folk = (short) 11,
+    Gospel = (short) 12,
+    HipHop = (short) 13,
+    Jazz = (short) 14,
+    Latin = (short) 15,
+    Musical = (short) 16,
+    NewAge = (short) 17,
+    Opera = (short) 18,
+    Operetta = (short) 19,
+    Pop = (short) 20,
+    Rap = (short) 21,
+    Reggae = (short) 22,
+    RhythmAndBlues = (short) 24,
+    Rock = (short) 23,
+    SoundEffects = (short) 25,
+    Soundtrack = (short) 26,
+    SpokenWord = (short) 27,
+    Unknown = (short) 1,
+    Unspecified = (short) 0,
+    WorldMusic = (short) 28,
+
+  }
+
+}
+```
+
+### Type: EBU
+
+```cs
+public static class EBU {
+
+  public enum LanguageCode : byte {
+
+    Albanian = (byte) 1,
+    Amharic = (byte) 127,
+    Arabic = (byte) 126,
+    Armenian = (byte) 125,
+    Assamese = (byte) 124,
+    Azerbaijani = (byte) 123,
+    Bambora = (byte) 122,
+    Basque = (byte) 13,
+    Bengali = (byte) 120,
+    Bielorussian = (byte) 121,
+    Breton = (byte) 2,
+    Bulgarian = (byte) 119,
+    Burmese = (byte) 118,
+    Catalan = (byte) 3,
+    Chinese = (byte) 117,
+    Churash = (byte) 116,
+    Croatian = (byte) 4,
+    Czech = (byte) 6,
+    Danish = (byte) 7,
+    Dari = (byte) 115,
+    Dutch = (byte) 29,
+    English = (byte) 9,
+    Esperanto = (byte) 11,
+    Estonian = (byte) 12,
+    Faroese = (byte) 14,
+    Finnish = (byte) 39,
+    Flemish = (byte) 42,
+    French = (byte) 15,
+    Frisian = (byte) 16,
+    Fulani = (byte) 114,
+    Gaelic = (byte) 18,
+    Galician = (byte) 19,
+    Georgian = (byte) 113,
+    German = (byte) 8,
+    Greek = (byte) 112,
+    Gujurati = (byte) 111,
+    Gurani = (byte) 110,
+    Hausa = (byte) 109,
+    Hebrew = (byte) 108,
+    Hindi = (byte) 107,
+    Hungarian = (byte) 27,
+    Icelandic = (byte) 20,
+    Indonesian = (byte) 106,
+    Irish = (byte) 17,
+    Italian = (byte) 21,
+    Japanese = (byte) 105,
+    Kannada = (byte) 104,
+    Kazakh = (byte) 103,
+    Khmer = (byte) 102,
+    Korean = (byte) 101,
+    Laotian = (byte) 100,
+    Lappish = (byte) 22,
+    Latin = (byte) 23,
+    Latvian = (byte) 24,
+    Lithuanian = (byte) 26,
+    Luxembourgian = (byte) 25,
+    Macedonian = (byte) 99,
+    Malagasay = (byte) 98,
+    Malaysian = (byte) 97,
+    Maltese = (byte) 28,
+    Marathi = (byte) 95,
+    Moldavian = (byte) 96,
+    Ndebele = (byte) 94,
+    Nepali = (byte) 93,
+    Norwegian = (byte) 30,
+    Occitan = (byte) 31,
+    Oriya = (byte) 92,
+    Papamiento = (byte) 91,
+    Persian = (byte) 90,
+    Polish = (byte) 32,
+    Portuguese = (byte) 33,
+    Punjabi = (byte) 89,
+    Pushtu = (byte) 88,
+    Quechua = (byte) 87,
+    Romanian = (byte) 34,
+    Romansh = (byte) 35,
+    Russian = (byte) 86,
+    Ruthenian = (byte) 85,
+    Serbian = (byte) 36,
+    SerboCroat = (byte) 84,
+    Shona = (byte) 83,
+    Sinhalese = (byte) 82,
+    Slovak = (byte) 37,
+    Slovenian = (byte) 38,
+    Somali = (byte) 81,
+    Spanish = (byte) 10,
+    SrananTongo = (byte) 80,
+    Swahili = (byte) 79,
+    Swedish = (byte) 40,
+    Tadzhik = (byte) 78,
+    Tamil = (byte) 77,
+    Tatar = (byte) 76,
+    Telugu = (byte) 75,
+    Thai = (byte) 74,
+    Turkish = (byte) 41,
+    Ukrainian = (byte) 73,
+    Unknown = (byte) 0,
+    Urdu = (byte) 72,
+    Uzbek = (byte) 71,
+    Vietnamese = (byte) 70,
+    Wallon = (byte) 43,
+    Welsh = (byte) 5,
+    Zulu = (byte) 69,
+
+  }
+
+}
+```


### PR DESCRIPTION
- update GitHub Actions
- drop AppVeyor builds
  - instead, use GitHub Actions for CI
- enable Dependabot for GitHub Actions and configure labels for it
- set `AssemblyIsComVisible` to `false` in the project file
  - allows dropping the `AssemblyInfo.cs` file
- add "public API" reference files
- align copyright years between license file and project
- target `net6.0` and `net8.0` only
  - bump version to 4.0.0-pre