### PR TITLE
Fix internal data structure fixups

### DIFF
--- a/MetaBrainz.MusicBrainz.DiscId/Platforms/Linux.cs
+++ b/MetaBrainz.MusicBrainz.DiscId/Platforms/Linux.cs
@@ -55,24 +55,18 @@ internal sealed class Linux() : Unix(Linux.Features) {
 
   private static RedBook.CDTextGroup? GetCdTextInfo(UnixFileDescriptor fd) {
     LibC.Linux.ReadCdText(fd, out var cdText);
-    cdText.FixUp();
     return cdText.Data.Packs is not null ? cdText.Data : null;
   }
 
   private static string GetMediaCatalogNumber(UnixFileDescriptor fd) {
     LibC.Linux.ReadMediaCatalogNumber(fd, out var mcn);
-    mcn.FixUp();
     return mcn.Status.IsValid ? Encoding.ASCII.GetString(mcn.MCN) : "";
   }
 
-  private static void GetTableOfContents(UnixFileDescriptor fd, out MMC.TOCDescriptor toc) {
-    LibC.Linux.ReadTOC(fd, out toc);
-    toc.FixUp(false);
-  }
+  private static void GetTableOfContents(UnixFileDescriptor fd, out MMC.TOCDescriptor toc) => LibC.Linux.ReadTOC(fd, out toc);
 
   private static string GetTrackIsrc(UnixFileDescriptor fd, byte track) {
     LibC.Linux.ReadTrackISRC(fd, track, out var isrc);
-    isrc.FixUp();
     return isrc.Status.IsValid ? Encoding.ASCII.GetString(isrc.ISRC) : string.Empty;
   }
 

--- a/MetaBrainz.MusicBrainz.DiscId/Platforms/NativeApi/LibC.Linux.cs
+++ b/MetaBrainz.MusicBrainz.DiscId/Platforms/NativeApi/LibC.Linux.cs
@@ -194,6 +194,7 @@ internal static partial class LibC {
       catch (Exception e) {
         throw new IOException("Failed to retrieve CD-TEXT information.", e);
       }
+      cdText.FixUp();
     }
 
     public static void ReadMediaCatalogNumber(UnixFileDescriptor fd, out MMC.SubChannelMediaCatalogNumber mcn) {
@@ -204,6 +205,7 @@ internal static partial class LibC {
       catch (Exception e) {
         throw new IOException("Failed to retrieve media catalog number.", e);
       }
+      mcn.FixUp();
     }
 
     public static void ReadTOC(UnixFileDescriptor fd, out MMC.TOCDescriptor toc) {
@@ -214,6 +216,7 @@ internal static partial class LibC {
       catch (Exception e) {
         throw new IOException("Failed to retrieve table of contents.", e);
       }
+      toc.FixUp(false);
     }
 
     public static void ReadTrackISRC(UnixFileDescriptor fd, byte track, out MMC.SubChannelISRC isrc) {
@@ -224,6 +227,7 @@ internal static partial class LibC {
       catch (Exception e) {
         throw new IOException($"Failed to retrieve ISRC for track {track}.", e);
       }
+      isrc.FixUp();
     }
 
     private static void SendSCSIRequest<TCommand, TData>(UnixFileDescriptor fd, ref TCommand cmd,

--- a/MetaBrainz.MusicBrainz.DiscId/Platforms/Windows.cs
+++ b/MetaBrainz.MusicBrainz.DiscId/Platforms/Windows.cs
@@ -50,7 +50,6 @@ internal sealed class Windows() : Platform(Windows.Features) {
 
   private static string GetMediaCatalogNumber(SafeFileHandle hDevice) {
     Kernel32.ReadMediaCatalogNumber(hDevice, out var mcn, out var length);
-    mcn.FixUp();
     var expected = mcn.Header.DataLength + Marshal.SizeOf(mcn.Header);
     if (length != expected) {
       Debug.Print($"I/O: MCN has data length as {expected} but {length} bytes were read.");


### PR DESCRIPTION
Media Catalog Number retrieval on Windows was broken due to a double fixup.

This resolves that, and moves fixups to the native side for Linux, to match the other platforms.
