### PR TITLE
Improve tracing and make it configurable

### DIFF
--- a/MetaBrainz.MusicBrainz.DiscId/MetaBrainz.MusicBrainz.DiscId.csproj
+++ b/MetaBrainz.MusicBrainz.DiscId/MetaBrainz.MusicBrainz.DiscId.csproj
@@ -14,7 +14,7 @@
     <PackageCopyrightYears>2016-2025</PackageCopyrightYears>
     <PackageRepositoryName>MetaBrainz.MusicBrainz.DiscId</PackageRepositoryName>
     <PackageTags>MusicBrainz discid audio cd cd-text isrc upc ean libdiscid</PackageTags>
-    <Version>5.0.1-pre</Version>
+    <Version>5.1.0-pre</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/MetaBrainz.MusicBrainz.DiscId/MetaBrainz.MusicBrainz.DiscId.csproj
+++ b/MetaBrainz.MusicBrainz.DiscId/MetaBrainz.MusicBrainz.DiscId.csproj
@@ -6,10 +6,8 @@
   <PropertyGroup>
     <Authors>Zastai</Authors>
     <Title>MusicBrainz DiscID Library</Title>
-    <Description>
-      This package provides classes for accessing information about a CD (its MusicBrainz Disc ID, EAN/ISRC values,
-      CD-TEXT info, ...).
-    </Description>
+    <!-- This ends up in the assembly attribute exactly as present here _including whitespace and line breaks_! -->
+    <Description>This package provides classes for accessing information about an Audio CD: its MusicBrainz Disc ID, EAN/ISRC values, CD-TEXT info, ...).</Description>
     <PackageCopyrightOwners>Tim Van Holder</PackageCopyrightOwners>
     <PackageCopyrightYears>2016-2025</PackageCopyrightYears>
     <PackageRepositoryName>MetaBrainz.MusicBrainz.DiscId</PackageRepositoryName>

--- a/MetaBrainz.MusicBrainz.DiscId/Platforms/Windows.cs
+++ b/MetaBrainz.MusicBrainz.DiscId/Platforms/Windows.cs
@@ -36,19 +36,16 @@ internal sealed class Windows() : Platform(Windows.Features) {
     Kernel32.ReadCdText(hDevice, out var cdText, out var length);
     var expected = cdText.DataLength + Marshal.SizeOf(cdText.DataLength);
     if (length != expected) {
-      TableOfContents.TraceSource.TraceEvent(TraceEventType.Warning, 1300,
-                                             "The CD TEXT data reports a total size of {0} bytes, but only {1} bytes were read.",
-                                             expected, length);
+      Tracing.Warning(1300, "The CD TEXT data reports a total size of {0} bytes, but only {1} bytes were read.", expected, length);
     }
     if (length < expected) {
       throw new IOException($"CD-TEXT Retrieval: incomplete data read ({length} of {expected} bytes).");
     }
     if (cdText.Data.Packs is not null) {
-      TableOfContents.TraceSource.TraceEvent(TraceEventType.Verbose, 1301, "CD-TEXT info read successfully (packs: {0}).",
-                                             cdText.Data.Packs.Length);
+      Tracing.Verbose(1301, "CD-TEXT info read successfully (packs: {0}).", cdText.Data.Packs.Length);
       return cdText.Data;
     }
-    TableOfContents.TraceSource.TraceEvent(TraceEventType.Verbose, 1302, "CD-TEXT info read successfully, but it is empty.");
+    Tracing.Verbose(1302, "CD-TEXT info read successfully, but it is empty.");
     return null;
   }
 
@@ -56,15 +53,13 @@ internal sealed class Windows() : Platform(Windows.Features) {
     Kernel32.ReadMediaCatalogNumber(hDevice, out var mcn, out var length);
     var expected = mcn.Header.DataLength + Marshal.SizeOf(mcn.Header);
     if (length != expected) {
-      TableOfContents.TraceSource.TraceEvent(TraceEventType.Warning, 1200,
-                                             "The MCN reports a total data size of {0} bytes, but only {1} bytes were read.",
-                                             expected, length);
+      Tracing.Warning(1200, "The MCN reports a total data size of {0} bytes, but only {1} bytes were read.", expected, length);
     }
     if (length < expected) {
       throw new IOException($"MCN Retrieval: incomplete data read ({length} of {expected} bytes).");
     }
     var result = mcn.Status.IsValid ? Encoding.ASCII.GetString(mcn.MCN) : string.Empty;
-    TableOfContents.TraceSource.TraceEvent(TraceEventType.Verbose, 1201, "MCN read successfully: [{0}].", result);
+    Tracing.Verbose(1201, "MCN read successfully: [{0}].", result);
     return result;
   }
 
@@ -72,30 +67,25 @@ internal sealed class Windows() : Platform(Windows.Features) {
     Kernel32.ReadTOC(hDevice, out toc, out var length);
     var expected = toc.DataLength + Marshal.SizeOf(toc.DataLength);
     if (length != expected) {
-      TableOfContents.TraceSource.TraceEvent(TraceEventType.Warning, 1000,
-                                             "The TOC reports a total data size of {0} bytes, but only {1} bytes were read.",
-                                             expected, length);
+      Tracing.Warning(1000, "The TOC reports a total data size of {0} bytes, but only {1} bytes were read.", expected, length);
     }
     if (length < expected) {
       throw new IOException($"TOC Retrieval: incomplete data read ({length} of {expected} bytes).");
     }
-    TableOfContents.TraceSource.TraceEvent(TraceEventType.Verbose, 1001, "TOC read successfully (tracks: {0} -> {1}).",
-                                           toc.FirstTrack, toc.LastTrack);
+    Tracing.Verbose(1001, "TOC read successfully (tracks: {0} -> {1}).", toc.FirstTrack, toc.LastTrack);
   }
 
   private static string GetTrackIsrc(SafeFileHandle hDevice, byte track) {
     Kernel32.ReadTrackISRC(hDevice, track, out var isrc, out var length);
     var expected = isrc.Header.DataLength + Marshal.SizeOf(isrc.Header);
     if (length != expected) {
-      TableOfContents.TraceSource.TraceEvent(TraceEventType.Warning, 1100,
-                                             "The ISRC reports a total data size of {0} bytes, but only {1} bytes were read.",
-                                             expected, length);
+      Tracing.Warning(1100, "The ISRC reports a total data size of {0} bytes, but only {1} bytes were read.", expected, length);
     }
     if (length < expected) {
       throw new IOException($"ISRC Retrieval: incomplete data read ({length} of {expected} bytes).");
     }
     var result = isrc.Status.IsValid ? Encoding.ASCII.GetString(isrc.ISRC) : string.Empty;
-    TableOfContents.TraceSource.TraceEvent(TraceEventType.Verbose, 1101, "ISRC read successfully: [{0}].", result);
+    Tracing.Verbose(1101, "ISRC read successfully: [{0}].", result);
     return result;
   }
 
@@ -113,7 +103,7 @@ internal sealed class Windows() : Platform(Windows.Features) {
         tracks = Track.Import(first, last, toc.Tracks, t => Windows.GetTrackIsrc(hDevice, t));
       }
       else {
-        TableOfContents.TraceSource.TraceEvent(TraceEventType.Verbose, 1199, "ISRC retrieval not requested or not available.");
+        Tracing.Verbose(1199, "ISRC retrieval not requested or not available.");
         tracks = Track.Import(first, last, toc.Tracks, null);
       }
     }
@@ -122,7 +112,7 @@ internal sealed class Windows() : Platform(Windows.Features) {
       mcn = Windows.GetMediaCatalogNumber(hDevice);
     }
     else {
-      TableOfContents.TraceSource.TraceEvent(TraceEventType.Verbose, 1299, "MCN retrieval not requested or not available.");
+      Tracing.Verbose(1299, "MCN retrieval not requested or not available.");
       mcn = null;
     }
     RedBook.CDTextGroup? cdTextInfo;
@@ -130,7 +120,7 @@ internal sealed class Windows() : Platform(Windows.Features) {
       cdTextInfo = Windows.GetCdTextInfo(hDevice);
     }
     else {
-      TableOfContents.TraceSource.TraceEvent(TraceEventType.Verbose, 1399, "CD-TEXT retrieval not requested or not available.");
+      Tracing.Verbose(1399, "CD-TEXT retrieval not requested or not available.");
       cdTextInfo = null;
     }
     return new TableOfContents(device, first, last, tracks, mcn, cdTextInfo);

--- a/MetaBrainz.MusicBrainz.DiscId/TableOfContents.cs
+++ b/MetaBrainz.MusicBrainz.DiscId/TableOfContents.cs
@@ -435,12 +435,12 @@ public sealed class TableOfContents {
     }
     var packs = cdTextGroup.Value.Packs;
     if (packs is null || packs.Length == 0) {
-      Trace.WriteLine("No CD-TEXT information (no packs found).", "CD-TEXT");
+      Tracing.Verbose(100, "No CD-TEXT packs found.");
       return;
     }
     // Assumption: Valid CD-TEXT blocks must have a SizeInfo entry.
     if (packs.Length < 3 || packs[^1].Type != RedBook.CDTextContentType.SizeInfo) {
-      Trace.WriteLine("No CD-TEXT information (packs do not end with SizeInfo data).", "CD-TEXT");
+      Tracing.Verbose(101, "No CD-TEXT information (packs do not end with SizeInfo data).");
       return;
     }
     RedBook.CDTextSizeInfo si;
@@ -456,7 +456,7 @@ public sealed class TableOfContents {
       --blockCount;
     }
     if (blockCount == 0) {
-      Trace.WriteLine("No CD-TEXT information (size info says there are 0 blocks).", "CD-TEXT");
+      Tracing.Verbose(102, "No CD-TEXT information (size info says there are 0 blocks).");
       return;
     }
     // Now set up the info arrays
@@ -493,20 +493,20 @@ public sealed class TableOfContents {
       var albumArranger = false;
       var albumMessage = false;
       var albumCode = false;
-      Trace.WriteLine($"Processing CD-TEXT block #{b + 1} (language: {si.LanguageCode[b]})...", "CD-TEXT");
+      Tracing.Verbose(103, "Processing CD-TEXT block #{0} (language: {1})...", b + 1, si.LanguageCode[b]);
       var dbcs = packs[p].IsUnicode;
       for (; p <= endPack; ++p) {
         var pack = packs[p];
         if (!pack.IsValid) {
-          Trace.WriteLine($"Ignoring pack #{p + 1} (type: {pack.Type}) because it failed the CRC check.", "CD-TEXT");
+          Tracing.Verbose(104, "Ignoring CD-TEXT pack #{0} (type: {1}) because it failed the CRC check.", p + 1, pack.Type);
           continue;
         }
         if (pack.IsExtension) {
-          Trace.WriteLine($"Ignoring pack #{p + 1} (type: {pack.Type}) because it's flagged as an extension.", "CD-TEXT");
+          Tracing.Verbose(105, "Ignoring CD-TEXT pack #{0} (type: {1}) because it's flagged as an extension.", p + 1, pack.Type);
           continue;
         }
         if (pack.IsUnicode != dbcs) {
-          Trace.WriteLine($"Pack #{p + 1} (type: {pack.Type}) has a mismatched DBCS flag.", "CD-TEXT");
+          Tracing.Verbose(106, "CD-TEXT Pack #{0} (type: {1}) has a mismatched DBCS flag.", p + 1, pack.Type);
         }
         switch (pack.Type) {
           case RedBook.CDTextContentType.Arranger:
@@ -561,7 +561,8 @@ public sealed class TableOfContents {
             }
             break;
           default:
-            Trace.WriteLine($"Ignoring pack #{p + 1} because it is of ignored or unsupported type '{pack.Type}'.", "CD-TEXT");
+            Tracing.Verbose(107, "Ignoring CD-TEXT pack #{0} because it is of ignored or unsupported type '{1}'.", p + 1,
+                            pack.Type);
             break;
         }
       }
@@ -569,53 +570,53 @@ public sealed class TableOfContents {
         si = Util.MarshalBytesToStructure<RedBook.CDTextSizeInfo>(sizeInfoBytes.ToArray());
       }
       else {
-        Trace.WriteLine("Ignoring this block because it does not include size info.", "CD-TEXT");
+        Tracing.Verbose(108, "Ignoring CD-TEXT block because it does not include size info.");
         continue;
       }
       // FIXME: Any skipped packs above will cause these checks to fail.
       if (si.PacksWithType80 * 12 != titleBytes.Count) {
-        Trace.WriteLine("Ignoring this block because it fails validation (pack count, type 80).", "CD-TEXT");
+        Tracing.Verbose(109, "Ignoring this CD-TEXT block because it fails validation (pack count, type 80).");
         continue;
       }
       if (si.PacksWithType81 * 12 != performerBytes.Count) {
-        Trace.WriteLine("Ignoring this block because it fails validation (pack count, type 81).", "CD-TEXT");
+        Tracing.Verbose(110, "Ignoring this CD-TEXT block because it fails validation (pack count, type 81).");
         continue;
       }
       if (si.PacksWithType82 * 12 != lyricistBytes.Count) {
-        Trace.WriteLine("Ignoring this block because it fails validation (pack count, type 82).", "CD-TEXT");
+        Tracing.Verbose(111, "Ignoring this CD-TEXT block because it fails validation (pack count, type 82).");
         continue;
       }
       if (si.PacksWithType83 * 12 != composerBytes.Count) {
-        Trace.WriteLine("Ignoring this block because it fails validation (pack count, type 83).", "CD-TEXT");
+        Tracing.Verbose(112, "Ignoring this CD-TEXT block because it fails validation (pack count, type 83).");
         continue;
       }
       if (si.PacksWithType84 * 12 != arrangerBytes.Count) {
-        Trace.WriteLine("Ignoring this block because it fails validation (pack count, type 84).", "CD-TEXT");
+        Tracing.Verbose(113, "Ignoring this CD-TEXT block because it fails validation (pack count, type 84).");
         continue;
       }
       if (si.PacksWithType85 * 12 != messageBytes.Count) {
-        Trace.WriteLine("Ignoring this block because it fails validation (pack count, type 85).", "CD-TEXT");
+        Tracing.Verbose(114, "Ignoring this CD-TEXT block because it fails validation (pack count, type 85).");
         continue;
       }
       if (si.PacksWithType86 * 12 != identBytes.Count) {
-        Trace.WriteLine("Ignoring this block because it fails validation (pack count, type 86).", "CD-TEXT");
+        Tracing.Verbose(115, "Ignoring this CD-TEXT block because it fails validation (pack count, type 86).");
         continue;
       }
       if (si.PacksWithType87 * 12 != genreBytes.Count) {
-        Trace.WriteLine("Ignoring this block because it fails validation (pack count, type 87).", "CD-TEXT");
+        Tracing.Verbose(116, "Ignoring this CD-TEXT block because it fails validation (pack count, type 87).");
         continue;
       }
       if (si.PacksWithType8E * 12 != codeBytes.Count) {
-        Trace.WriteLine("Ignoring this block because it fails validation (pack count, type 8E).", "CD-TEXT");
+        Tracing.Verbose(117, "Ignoring this CD-TEXT block because it fails validation (pack count, type 8E).");
         continue;
       }
       if (si.PacksWithType8F * 12 != sizeInfoBytes.Count) {
-        Trace.WriteLine("Ignoring this block because it fails validation (pack count, type 8F).", "CD-TEXT");
+        Tracing.Verbose(118, "Ignoring this CD-TEXT block because it fails validation (pack count, type 8F).");
         continue;
       }
       Encoding encoding;
       if (dbcs) {
-        Trace.WriteLine("This block contains DBCS data; assuming this means UTF-16.", "CD-TEXT");
+        Tracing.Verbose(119, "This CD-TEXT block contains DBCS data; assuming this means UTF-16.");
         encoding = Encoding.BigEndianUnicode;
       }
       else {
@@ -626,25 +627,32 @@ public sealed class TableOfContents {
           case RedBook.CDTextCharacterCode.ISO_8859_1:
             // FIXME: It's supposed to be a modified form of latin-1, but without the Blue Book, it's unclear what those
             //        modifications entail.
-            Trace.WriteLine("Using plain ISO-8859-1 as encoding; some characters may not be correct.", "CD-TEXT");
+            Tracing.Verbose(120, "Using plain ISO-8859-1 as CD-TEXT block encoding; some characters may not be correct.");
             encoding = Encoding.GetEncoding("iso-8859-1");
             break;
           case RedBook.CDTextCharacterCode.Korean:
-            Trace.WriteLine("Assuming EUC-KR as Korean encoding.", "CD-TEXT");
+            Tracing.Verbose(121, "Assuming EUC-KR as Korean CD-TEXT block encoding.");
             encoding = Encoding.GetEncoding("euc-kr");
             break;
           case RedBook.CDTextCharacterCode.MandarinChinese:
-            Trace.WriteLine("Assuming GB2312 as Mandarin Chinese encoding.", "CD-TEXT");
+            Tracing.Verbose(122, "Assuming GB2312 as Mandarin Chinese CD-TEXT block encoding.");
             encoding = Encoding.GetEncoding("gb2312");
             break;
           case RedBook.CDTextCharacterCode.MusicShiftJis:
             // FIXME: Without standard RIAJ RS506 it's unclear how this differs from plain Shift-JIS, but some comments online
             //        suggest it has a LOT of extra emoji.
-            Trace.WriteLine("Using plain Shift-Jis as encoding; some characters may not be correct.", "CD-TEXT");
+            Tracing.Verbose(123, "Using plain Shift-Jis as CD-TEXT block encoding; some characters may not be correct.");
             encoding = Encoding.GetEncoding("iso-2022-jp");
             break;
           default:
-            Trace.WriteLine($"Ignoring this block because it specifies an unknown character set ({si.CharacterCode}).", "CD-TEXT");
+            if ((byte) si.CharacterCode >= 0x83) {
+              Tracing.Verbose(124, "Ignoring this CD-TEXT block because it specifies a reserved character set ({0}).",
+                              si.CharacterCode);
+            }
+            else {
+              Tracing.Verbose(125, "Ignoring this CD-TEXT block because it specifies an unknown character set ({0}).",
+                              si.CharacterCode);
+            }
             continue;
         }
       }
@@ -660,12 +668,17 @@ public sealed class TableOfContents {
         genre = (BlueBook.Genre) code;
         genreDescription = latin1.GetString(rawGenre, 2, rawGenre.Length - 2).TrimEnd('\0');
         if (genreDescription.Length == 0) {
+          Tracing.Verbose(126, "CD-TEXT: Genre set as {0:D} ({0}), with no description.", genre);
           genreDescription = null;
+        }
+        else {
+          Tracing.Verbose(127, "CD-TEXT: Genre set as {0:D} ({0}) [{1}].", genre, genreDescription);
         }
       }
       string? ident = null;
       if (identBytes.Count > 0) {
         ident = latin1.GetString(identBytes.ToArray()).TrimEnd('\0');
+        Tracing.Verbose(128, "CD-TEXT: Disc identification set as [{0}].", ident);
       }
       var tracks = si.LastTrack - si.FirstTrack + 1;
       var titleCount = tracks + (albumTitle ? 1 : 0);
@@ -797,18 +810,23 @@ public sealed class TableOfContents {
       parts[items - 1] = parts[items - 1].TrimEnd('\0');
     }
     if (parts.Length < items) {
-      Trace.WriteLine($"Not enough values provided in the {type} packs (expected {items}, got {parts.Length}).", "CD-TEXT");
+      Tracing.Verbose(200, "CD-TEXT: Not enough values provided in the {0} packs (expected {1}, got {2}).", type, items,
+                      parts.Length);
     }
     for (var i = 0; i < parts.Length; ++i) {
-      if (parts[i] != "\t") {
-        continue;
-      }
       // TAB means "same as preceding value"
-      if (i == 0) {
-        Trace.WriteLine($"Found a TAB in the first value of the {type} packs.", "CD-TEXT");
+      if (parts[i] == "\t") {
+        if (i == 0) {
+          Tracing.Verbose(201, "CD-TEXT: Found a TAB in the first value of the {0} packs.", type);
+          parts[i] = "";
+        }
+        else {
+          parts[i] = parts[i - 1];
+          Tracing.Verbose(202, "CD-TEXT: Value #{0} for content type {1:X} ({1}) is the same as the previous value.", i + 1, type);
+        }
       }
       else {
-        parts[i] = parts[i - 1];
+        Tracing.Verbose(203, "CD-TEXT: Value #{0} for content type {1:X} ({1}) is [{2}].", i + 1, type, parts[i]);
       }
     }
     return parts;

--- a/MetaBrainz.MusicBrainz.DiscId/TableOfContents.cs
+++ b/MetaBrainz.MusicBrainz.DiscId/TableOfContents.cs
@@ -58,7 +58,7 @@ public sealed class TableOfContents {
   public static string DefaultWebSite { get; set; } = "musicbrainz.org";
 
   /// <summary>The trace source (named 'MetaBrainz.MusicBrainz.DiscId') used by this class.</summary>
-  public static readonly TraceSource TraceSource = new("MetaBrainz.MusicBrainz.DiscId", SourceLevels.Off);
+  public static readonly TraceSource TraceSource = Tracing.Source;
 
   #endregion
 

--- a/MetaBrainz.MusicBrainz.DiscId/TableOfContents.cs
+++ b/MetaBrainz.MusicBrainz.DiscId/TableOfContents.cs
@@ -57,14 +57,17 @@ public sealed class TableOfContents {
   /// </summary>
   public static string DefaultWebSite { get; set; } = "musicbrainz.org";
 
-  /// <summary>Determines whether the specified feature(s) are supported for use with <see cref="ReadDisc"/>.</summary>
-  /// <param name="feature">The feature(s) to test.</param>
-  /// <returns><see langword="true"/> if all specified features are supported; <see langword="false"/> otherwise.</returns>
-  public static bool HasReadFeature(DiscReadFeature feature) => TableOfContents.Platform.HasFeature(feature);
+  /// <summary>The trace source (named 'MetaBrainz.MusicBrainz.DiscId') used by this class.</summary>
+  public static readonly TraceSource TraceSource = new("MetaBrainz.MusicBrainz.DiscId", SourceLevels.Off);
 
   #endregion
 
   #region Static Methods
+
+  /// <summary>Determines whether the specified feature(s) are supported for use with <see cref="ReadDisc"/>.</summary>
+  /// <param name="feature">The feature(s) to test.</param>
+  /// <returns><see langword="true"/> if all specified features are supported; <see langword="false"/> otherwise.</returns>
+  public static bool HasReadFeature(DiscReadFeature feature) => TableOfContents.Platform.HasFeature(feature);
 
   /// <summary>
   /// Reads the table of contents for the current disc in the specified device, getting the requested information.
@@ -154,8 +157,8 @@ public sealed class TableOfContents {
 
   /// <summary>Returns a string representing the TOC.</summary>
   /// <returns>
-  ///   A string consisting of the following values, separated by a space: the first track number, the last track number,
-  ///   the total length of the disc in sectors, and the offsets of all tracks.
+  /// A string consisting of the following values, separated by a space: the first track number, the last track number, the total
+  /// length of the disc in sectors, and the offsets of all tracks.
   /// </returns>
   public override string ToString() {
     if (this._stringForm is not null) {
@@ -211,8 +214,8 @@ public sealed class TableOfContents {
     public TimeSpan StartTime { get; }
 
     /// <summary>
-    ///   The track-level CD-TEXT data.
-    ///   If no such data is available, this is null; otherwise, it will have as many entries as <see cref="TextLanguages"/>.
+    /// The track-level CD-TEXT data. If no such data is available, this is <see langword="null"/>; otherwise, it will have as many
+    /// entries as <see cref="TextLanguages"/>.
     /// </summary>
     public IReadOnlyList<TrackText>? TextInfo { get; }
 
@@ -769,9 +772,9 @@ public sealed class TableOfContents {
     var uri = new UriBuilder(this.UrlScheme, this.WebSite, this.Port, "cdtoc/attach", null);
     var query = new StringBuilder();
     query.Append("id=").Append(Uri.EscapeDataString(this.DiscId));
+    // Avoids having to explicitly run Uri.EscapeDataString on all the integers
     var culture = Thread.CurrentThread.CurrentCulture;
-    Thread.CurrentThread.CurrentCulture =
-      CultureInfo.InvariantCulture; // Avoids having to explicitly run Uri.EscapeDataString on all the integers
+    Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
     try {
       query.Append("&tracks=").Append(1 + this.LastTrack - this.FirstTrack).Append("&toc=");
       this.AppendTocString(query, '+');

--- a/MetaBrainz.MusicBrainz.DiscId/Tracing.cs
+++ b/MetaBrainz.MusicBrainz.DiscId/Tracing.cs
@@ -1,0 +1,25 @@
+﻿using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace MetaBrainz.MusicBrainz.DiscId;
+
+internal static class Tracing {
+
+  public static readonly TraceSource Source = new("MetaBrainz.MusicBrainz.DiscId", SourceLevels.Off);
+
+  public static void Critical(int id, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string message, params object?[]? args)
+    => Tracing.Source.TraceEvent(TraceEventType.Critical, id, message, args);
+
+  public static void Error(int id, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string message, params object?[]? args)
+    => Tracing.Source.TraceEvent(TraceEventType.Error, id, message, args);
+
+  public static void Info(int id, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string message, params object?[]? args)
+    => Tracing.Source.TraceEvent(TraceEventType.Information, id, message, args);
+
+  public static void Verbose(int id, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string message, params object?[]? args)
+    => Tracing.Source.TraceEvent(TraceEventType.Verbose, id, message, args);
+
+  public static void Warning(int id, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string message, params object?[]? args)
+    => Tracing.Source.TraceEvent(TraceEventType.Warning, id, message, args);
+
+}

--- a/README.md
+++ b/README.md
@@ -11,7 +11,80 @@ Windows, Linux and FreeBSD are supported.
 
 Support for macOS is unlikely, because I have no access to a system.
 
+
+## Debugging
+
+The `TableOfContents` class provides a `TraceSource` that can be used to
+configure debug output; its name is `MetaBrainz.MusicBrainz.DiscId`.
+
+### Configuration
+
+#### In Code
+
+In code, you can enable tracing like follows:
+
+```cs
+// Use the default switch, turning it on.
+TableOfContents.TraceSource.Switch.Level = SourceLevels.All;
+
+// Alternatively, use your own switch so multiple things can be
+// enabled/disabled at the same time.
+var mySwitch = new TraceSwitch("MyAppDebugSwitch", "All");
+TableOfContents.TraceSource.Switch = mySwitch;
+
+// By default, there is a single listener that writes trace events to
+// the debug output (typically only seen in an IDE's debugger). You can
+// add (and remove) listeners as desired.
+var listener = new ConsoleTraceListener {
+  Name = "MyAppConsole",
+  TraceOutputOptions = TraceOptions.DateTime | TraceOptions.ProcessId,
+};
+TableOfContents.TraceSource.Listeners.Clear();
+TableOfContents.TraceSource.Listeners.Add(listener);
+```
+
+#### In Configuration
+
+Your application can also be set up to read tracing configuration from
+the application configuration file. To do so, the following needs to be
+added to its startup code:
+
+```cs
+System.Diagnostics.TraceConfiguration.Register();
+```
+
+(Provided by the `System.Configuration.ConfigurationManager` package.)
+
+The application config file can then have a `system.diagnostics` section
+where sources, switches and listeners can be configured.
+
+```xml
+<configuration>
+  <system.diagnostics>
+    <sharedListeners>
+      <add name="console" type="System.Diagnostics.ConsoleTraceListener" traceOutputOptions="DateTime,ProcessId" />
+    </sharedListeners>
+    <sources>
+      <source name="MetaBrainz.MusicBrainz.DiscId" switchName="MetaBrainz.MusicBrainz.DiscId">
+        <listeners>
+          <add name="console" />
+          <add name="lb-log" type="System.Diagnostics.TextWriterTraceListener" initializeData="lb.log" />
+        </listeners>
+      </source>
+    </sources>
+    <switches>
+      <add name="MetaBrainz.MusicBrainz.DiscId" value="All" />
+    </switches>
+  </system.diagnostics>
+</configuration>
+```
+
+## Release Notes
+
+These are available [on GitHub][release-notes].
+
 [libdiscid]: https://github.com/metabrainz/libdiscid
+[release-notes]: https://github.com/Zastai/MetaBrainz.MusicBrainz.DiscId/releases
 
 [CI-S]: https://github.com/Zastai/MetaBrainz.MusicBrainz.DiscId/actions/workflows/build.yml/badge.svg
 [CI-L]: https://github.com/Zastai/MetaBrainz.MusicBrainz.DiscId/actions/workflows/build.yml

--- a/public-api/MetaBrainz.MusicBrainz.DiscId.net8.0.cs.md
+++ b/public-api/MetaBrainz.MusicBrainz.DiscId.net8.0.cs.md
@@ -113,6 +113,8 @@ public sealed class TableOfContents {
 
   public const int MaxSectors = 449999;
 
+  public static readonly System.Diagnostics.TraceSource TraceSource;
+
   public const int XAInterval = 11400;
 
   System.Collections.Generic.IEnumerable<string> AvailableDevices {


### PR DESCRIPTION
This adjusts all tracing done by library code to go via a `TraceSource` object, allowing consuming code to configure where that tracing goes to.

(This also adjusts ISRC reading on Windows, retrying reads when they succeed but return an ISRC marked as invalid.)